### PR TITLE
Initial Implementation

### DIFF
--- a/lib/simplest_status.rb
+++ b/lib/simplest_status.rb
@@ -1,5 +1,12 @@
 require "simplest_status/version"
 
 module SimplestStatus
-  # Your code goes here...
+  autoload :StatusCollection, 'simplest_status/status_collection'
+  autoload :ModelMethods,     'simplest_status/model_methods'
+
+  def statuses(*status_list)
+    @statuses ||= status_list.reduce(StatusCollection.new) do |collection, status|
+      collection.add(status)
+    end.tap { public_send(:include, ModelMethods) }
+  end
 end

--- a/lib/simplest_status/model_methods.rb
+++ b/lib/simplest_status/model_methods.rb
@@ -1,0 +1,29 @@
+module SimplestStatus
+  module ModelMethods
+    def self.included(base)
+      base.class_eval do
+        statuses.each do |status_info|
+          const_set(status_info.constant_name, status_info.value)
+
+          define_singleton_method status_info.symbol do
+            where(:status => status_info.value)
+          end
+
+          define_method "#{status_info.symbol}?" do
+            status == status_info.value
+          end
+
+          define_method status_info.symbol do
+            update_attributes(:status => status_info.value)
+          end
+
+          define_method :status_label do
+            self.class.statuses.label_for(status)
+          end
+        end
+
+        validates :status, :presence => true, :inclusion => { :in => proc { statuses.values } }
+      end
+    end
+  end
+end

--- a/lib/simplest_status/status.rb
+++ b/lib/simplest_status/status.rb
@@ -1,0 +1,42 @@
+module SimplestStatus
+  class Status
+    attr_reader :name, :value
+
+    def initialize(input)
+      @name, @value = Array(input)
+    end
+
+    def symbol
+      name.to_sym
+    end
+
+    def string
+      name.to_s
+    end
+    alias :to_s :string
+
+    def to_hash
+      { name => value }
+    end
+
+    def matches?(input)
+      [string, value.to_s].include? input.to_s
+    end
+
+    def constant_name
+      string.upcase
+    end
+
+    def label
+      string.split(/[\s_-]+/).map(&:capitalize).join(' ')
+    end
+
+    def for_select
+      [label, value]
+    end
+
+    def ==(status)
+      Hash(self) == Hash(status)
+    end
+  end
+end

--- a/lib/simplest_status/status_collection.rb
+++ b/lib/simplest_status/status_collection.rb
@@ -1,0 +1,34 @@
+module SimplestStatus
+  autoload :Status, 'simplest_status/status'
+
+  class StatusCollection < Hash
+    def each
+      super do |status|
+        yield Status.new(status)
+      end
+    end
+
+    def [](status_name)
+      status_for(status_name).value
+    end
+    alias :value_for :[]
+
+    def status_for(input)
+      find do |status|
+        status.matches? input
+      end
+    end
+
+    def add(status, value = self.size)
+      self.merge!(status => value)
+    end
+
+    def label_for(value)
+      status_for(value).label
+    end
+
+    def for_select
+      map(&:for_select)
+    end
+  end
+end

--- a/spec/simplest_status/model_methods_spec.rb
+++ b/spec/simplest_status/model_methods_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe SimplestStatus::ModelMethods do
+  class MockModel < Struct.new(:status)
+    class << self
+      attr_accessor :validation_input
+
+      def validates(field, options)
+        self.validation_input = options.merge(:field => field)
+      end
+
+      def statuses
+        SimplestStatus::StatusCollection[:boom, 0, :shaka, 1, :laka, 2] 
+      end
+    end
+
+    include SimplestStatus::ModelMethods
+  end
+
+  describe "when included in a model" do
+    it "sets a constant for each status" do
+      expect(MockModel::BOOM).to eq 0
+      expect(MockModel::SHAKA).to eq 1
+      expect(MockModel::LAKA).to eq 2
+    end
+
+    it "defines a class-level scopes" do
+      expect(MockModel).to receive(:where).with(:status => 1)
+
+      MockModel.shaka
+    end
+
+    it "defines instance-level predicate methods" do
+      MockModel.new(:boom).tap do |subject|
+        expect(subject).to receive(:update_attributes).with(:status => 2)
+
+        subject.laka
+      end
+    end
+
+    it "defines an instance-level #status_label method" do
+      expect(MockModel.new(:boom).status_label).to eq 'Boom'
+      expect(MockModel.new(:shaka).status_label).to eq 'Shaka'
+      expect(MockModel.new(:laka).status_label).to eq 'Laka'
+    end
+    
+    it "sets up the correct model validations" do
+      MockModel.validation_input.tap do |validation|
+        expect(validation[:field]).to eq :status
+        expect(validation[:presence]).to eq true
+        expect(validation[:inclusion][:in].call).to eq [0, 1, 2]
+      end
+    end
+  end
+end

--- a/spec/simplest_status/status_collection_spec.rb
+++ b/spec/simplest_status/status_collection_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+RSpec.describe SimplestStatus::StatusCollection do
+  let(:boom)  { SimplestStatus::Status.new([:boom, 0]) }
+  let(:shaka) { SimplestStatus::Status.new([:shaka, 1]) }
+  let(:laka)  { SimplestStatus::Status.new([:laka, 2]) }
+
+  subject { described_class.new }
+
+  describe "#each" do
+    subject { described_class.new.merge!(boom: 0, shaka: 1, laka: 2) }
+
+    it "yields each key/value as a Simplest::Status object" do
+      expect do |block|
+        subject.each(&block).to yield_successive_args(boom, shaka, laka)
+      end
+    end
+  end
+
+  describe "#add" do
+    it "returns the collection with the added record" do
+      expect(subject.add(:testing)).to eq(testing: 0)
+    end
+
+    context "when given an explicit value" do
+      it { expect(subject.add(:testing, 5)).to eq(testing: 5) }
+    end
+  end
+
+  describe "#status_for" do
+    subject { described_class[:testing, 5] }
+
+    context "given input that matches a status's name" do
+      it "returns a SimplestStatus::Status with the matching name" do
+        expect(subject.status_for(:testing)).to eq SimplestStatus::Status.new([:testing, 5])
+      end
+    end
+
+    context "given input that matches a status's value" do
+      it "returns a SimplestStatus::Status with the matching value" do
+        expect(subject.status_for(5)).to eq SimplestStatus::Status.new([:testing, 5])
+      end
+    end
+
+    context "given input that does not match a status's name or value" do
+      it "returns nil" do
+        expect(subject.status_for('boom')).to eq nil
+      end
+    end
+  end
+
+  describe "#[] and #value_for" do
+    context "given a value that matches an existing key" do
+      subject { described_class[:testing, 0] }
+
+      it { expect(subject[:testing]).to eq 0 }
+      it { expect(subject.value_for(:testing)).to eq 0 }
+    end
+
+    context "given a value that matches an existing key once converted" do
+      let(:symbol) { described_class[:testing, 0] }
+      let(:string) { described_class['testing', 0] }
+
+      it { expect(symbol['testing']).to eq 0 }
+      it { expect(string[:testing]).to eq 0 }
+
+      it { expect(symbol.value_for('testing')).to eq 0 }
+      it { expect(string.value_for(:testing)).to eq 0 }
+    end
+  end
+
+  describe "#label_for" do
+    subject { described_class[:such_label, 1337] }
+
+    it { expect(subject.label_for('such_label')).to eq 'Such Label' }
+    it { expect(subject.label_for(1337)).to eq 'Such Label' }
+  end
+
+  describe "#for_select" do
+    subject { described_class.new.merge!(boom: 0, shaka: 1, laka: 2) }
+
+    it { expect(subject.for_select).to eq [['Boom', 0], ['Shaka', 1], ['Laka', 2]] }
+  end
+end

--- a/spec/simplest_status/status_spec.rb
+++ b/spec/simplest_status/status_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe SimplestStatus::Status do
+  subject { described_class.new [:such_status, 1337] }
+
+  describe "#name" do
+    it { expect(subject.name).to eq :such_status }
+  end
+
+  describe "#value" do
+    it { expect(subject.value).to eq 1337 }
+  end
+
+  describe "#symbol" do
+    it { expect(subject.symbol).to eq :such_status }
+  end
+
+  describe "#string" do
+    it { expect(subject.string).to eq 'such_status' }
+  end
+
+  describe "#to_s" do
+    it { expect(subject.to_s).to eq 'such_status' }
+  end
+
+  describe "#to_hash" do
+    it { expect(subject.to_hash).to eq(:such_status => 1337) }
+  end
+
+  describe "#matches?" do
+    it { expect(subject.matches?(:such_status)).to eq true }
+    it { expect(subject.matches?('such_status')).to eq true }
+    it { expect(subject.matches?(1337)).to eq true }
+    it { expect(subject.matches?('1337')).to eq true }
+    it { expect(subject.matches?(:boom)).to eq false }
+  end
+
+  describe "#constant_name" do
+    it { expect(subject.constant_name).to eq 'SUCH_STATUS' }
+  end
+
+  describe "#label" do
+    it { expect(subject.label).to eq 'Such Status' }
+  end
+
+  describe "#for_select" do
+    it { expect(subject.for_select).to eq ['Such Status', 1337] }
+  end
+
+  describe "#==" do
+    it { expect(subject).to eq described_class.new [:such_status, 1337] }
+    it { expect(subject).to_not eq described_class.new [:very_status, 10] }
+  end
+end

--- a/spec/simplest_status_spec.rb
+++ b/spec/simplest_status_spec.rb
@@ -4,4 +4,18 @@ RSpec.describe SimplestStatus do
   it "has a version number" do
     expect(SimplestStatus::VERSION).not_to be nil
   end
+
+  context "when extended by a model" do
+    class EmptyModel
+      extend SimplestStatus
+    end
+
+    before do
+      allow(EmptyModel).to receive(:include).with(SimplestStatus::ModelMethods)
+    end
+
+    it "adds the .statuses method" do
+      expect(EmptyModel.statuses(:boom, :shaka, :laka)).to eq(:boom => 0, :shaka => 1, :laka => 2)
+    end
+  end
 end


### PR DESCRIPTION
## Overview

This PR introduces the basic set of functionality I envisioned for SimplestStatus.
## DSL

Assuming there's a model that has a `:status` field of type `integer`, the DSL is as follows:

```
class Post < ActiveRecord::Base
  extend SimplestStatus

  statuses :draft, :preview, :published, :archived
end
```
## Generated Methods

Given the above example, here's the various things you'll get on that `Post` model:

``` ruby

# Status List
Post.statuses # => { :draft => 0, :preview => 1, :published => 2, :archived => 3 }

# Constants
Post::DRAFT     # => 0
Post::PREVIEW   # => 1
Post::PUBLISHED # => 2
Post::ARCHIVED  # => 3

# Scopes
Post.draft
Post.preview
Post.published
Post.archived

# Predicate Methods
post = Post.new(:status => Post::DRAFT)
post.draft?     # => true
post.preview?   # => false
post.published? # => false
post.archived?  # => false

# Status Mutation Methods
post = Post.new(:status => Post::ARCHIVED)
post.draft      # status from Post::ARCHIVED to Post::DRAFT
post.preview    # status from Post::DRAFT to Post::PREVIEW
post.published  # status from Post::PREVIEW to Post::PUBLISHED
post.archived   # status from Post::PUBLISHED to Post::ARCHIVED

# Status Label Method
Post.new(:status => Post::DRAFT).status_label     # => 'Draft'
Post.new(:status => Post::PREVIEW).status_label   # => 'Preview'
Post.new(:status => Post::PUBLISHED).status_label # => 'Published'
Post.new(:status => Post::ARCHIVED).status_label  # => 'Archived'

# Select Form Helper
Post.statuses.for_select # => [['Draft', 0], ['Preview', 1], ['Published', 2], ['Archived', 3]]
```
## Reasoning

Started making it before I knew about Rails' `enum`.  This is -- at the moment -- specific to a model with a `status` column (can add additional flexibility down the road).  Gets you pretty much the same set of functionality as `enum` and then some -- also will work with older versions of Rails than 4.1 (when `enum` was introduced).
