### PR TITLE
Flexible Status Columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 .DS_Store
 *.gemfile.lock
+*.gem

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.1.0
   - 2.2.2
 gemfile:
-  - gemfiles/rails_20.gemfile
+  - gemfiles/rails_30.gemfile
   - gemfiles/rails_31.gemfile
   - gemfiles/rails_32.gemfile
   - gemfiles/rails_40.gemfile
@@ -14,7 +14,7 @@ gemfile:
 matrix:
   exclude:
     - rvm: 2.2.2
-      gemfile: gemfiles/rails_20.gemfile
+      gemfile: gemfiles/rails_30.gemfile
     - rvm: 2.2.2
       gemfile: gemfiles/rails_31.gemfile
     - rvm: 2.2.2

--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,5 @@
-appraise "rails-20" do
-  gem "rails", "~> 2.0.5"
+appraise "rails-30" do
+  gem "rails", "~> 3.0.0"
 end
 
 appraise "rails-31" do

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class Post < ActiveRecord::Base
 
   statuses :draft, :preview, :published, :archived
 
-  simple_status :locale, %i(english spanish russian)
+  simple_status :locale, [:english, :spanish, :russian]
 end
 ```
 This will generate a number of constants, methods, and model validations.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SimplestStatus [![Gem Version](https://badge.fury.io/rb/simplest_status.svg)](http://badge.fury.io/rb/simplest_status) [![Code Climate](https://codeclimate.com/github/vigetlabs/simplest_status/badges/gpa.svg)](https://codeclimate.com/github/vigetlabs/simplest_status) [![Test Coverage](https://codeclimate.com/github/vigetlabs/simplest_status/badges/coverage.svg)](https://codeclimate.com/github/vigetlabs/simplest_status/coverage) [![Build Status](https://travis-ci.org/vigetlabs/simplest_status.svg)]((https://travis-ci.org/vigetlabs/simplest_status))
 
-SimplestStatus is a gem built to provide simple, convenient status functionality for Rails models.  It's designed to work with practically every version of Rails (tested as far back as 2.0.5) and will work with Ruby 1.9.3 and up.
+SimplestStatus is a gem built to provide simple, convenient status functionality for Rails models.  It's designed to work with any currently-supported version of Rails (tested as far back as 3.0.0) and will work with Ruby 1.9.3 and up.
 
 SimplestStatus is similar to the recently introduced [`enum`](http://api.rubyonrails.org/classes/ActiveRecord/Enum.html) (debuted in Rails 4.1), but is different in that it doesn't rely on a particular version of Rails and it also provides additional functionality like constant-based status lookup, label helpers, and validations.
 

--- a/gemfiles/rails_30.gemfile
+++ b/gemfiles/rails_30.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 2.0.5"
+gem "rails", "~> 3.0.0"
 
 gemspec :path => "../"

--- a/lib/simplest_status.rb
+++ b/lib/simplest_status.rb
@@ -5,10 +5,10 @@ module SimplestStatus
   autoload :ModelMethods,     'simplest_status/model_methods'
 
   def statuses(*status_list)
-    instance_variable_get(:@statuses) || custom_status(:status, status_list)
+    instance_variable_get(:@statuses) || simple_status(:status, status_list)
   end
 
-  def custom_status(field_name, values)
+  def simple_status(field_name, values)
     status_collection_for(field_name, values).configure_for(self)
   end
 

--- a/lib/simplest_status.rb
+++ b/lib/simplest_status.rb
@@ -5,12 +5,18 @@ module SimplestStatus
   autoload :ModelMethods,     'simplest_status/model_methods'
 
   def statuses(*status_list)
-    @statuses ||= status_list.reduce(StatusCollection.new) do |collection, status|
-      collection.add(status)
-    end
+    instance_variable_get(:@statuses) || custom_status(:status, status_list)
+  end
 
-    send(:include, ModelMethods) unless ancestors.include? ModelMethods
+  def custom_status(field_name, values)
+    status_collection_for(field_name, values).configure_for(self)
+  end
 
-    @statuses
+  private
+
+  def status_collection_for(status_method, values)
+    values.reduce(StatusCollection.new(status_method)) do |collection, value|
+      collection.add(value)
+    end.configure_for(self)
   end
 end

--- a/lib/simplest_status.rb
+++ b/lib/simplest_status.rb
@@ -17,6 +17,6 @@ module SimplestStatus
   def status_collection_for(status_method, values)
     values.reduce(StatusCollection.new(status_method)) do |collection, value|
       collection.add(value)
-    end.configure_for(self)
+    end
   end
 end

--- a/lib/simplest_status/status_collection.rb
+++ b/lib/simplest_status/status_collection.rb
@@ -1,3 +1,5 @@
+require "active_support/inflector"
+
 module SimplestStatus
   autoload :Status, 'simplest_status/status'
 
@@ -14,9 +16,7 @@ module SimplestStatus
     alias :value_for :[]
 
     def status_for(input)
-      find do |status|
-        status.matches? input
-      end
+      find { |status| status.matches?(input) } || NullStatus.new
     end
 
     def add(status, value = self.size)
@@ -30,5 +30,21 @@ module SimplestStatus
     def for_select
       map(&:for_select)
     end
+
+    def configure_for(model)
+      tap { ModelMethods.new(model, self).add }
+    end
+
+    def status_name
+      default
+    end
+
+    def model_accessor
+      status_name.to_s.pluralize
+    end
+
+    private
+
+    NullStatus = Struct.new(:value)
   end
 end

--- a/spec/simplest_status/model_methods_spec.rb
+++ b/spec/simplest_status/model_methods_spec.rb
@@ -1,27 +1,31 @@
 require 'spec_helper'
 
 RSpec.describe SimplestStatus::ModelMethods do
-  class MockModel < Struct.new(:status)
+  class MockModel < Struct.new(:hype_level)
     class << self
       attr_accessor :validation_input
 
       def validates(field, options)
         self.validation_input = options.merge(:field => field)
       end
-
-      def statuses
-        SimplestStatus::StatusCollection[:boom, 0, :shaka, 1, :laka, 2] 
-      end
     end
 
-    include SimplestStatus::ModelMethods
-
-    def status
-      self.class.statuses[super]
+    def hype_level
+      self.class.hype_levels[super]
     end
   end
 
-  describe "when included in a model" do
+  let!(:statuses) { SimplestStatus::StatusCollection.new(:hype_level).merge!(:boom => 0, :shaka => 1, :laka => 2) }
+
+  subject { described_class.new(MockModel, statuses) }
+
+  describe "#add" do
+    before { subject.add }
+
+    it "defines and populates the model-level accessor" do
+      expect(MockModel.hype_levels).to eq(:boom => 0, :shaka => 1, :laka => 2)
+    end
+
     it "sets a constant for each status" do
       expect(MockModel::BOOM).to eq 0
       expect(MockModel::SHAKA).to eq 1
@@ -29,7 +33,7 @@ RSpec.describe SimplestStatus::ModelMethods do
     end
 
     it "defines a class-level scopes" do
-      expect(MockModel).to receive(:where).with(:status => 1)
+      expect(MockModel).to receive(:where).with(:hype_level => 1)
 
       MockModel.shaka
     end
@@ -42,23 +46,23 @@ RSpec.describe SimplestStatus::ModelMethods do
 
     it "defines instance-level status mutation methods" do
       MockModel.new(:boom).tap do |subject|
-        expect(subject).to receive(:update_attributes).with(:status => 2)
+        expect(subject).to receive(:update_attributes).with(:hype_level => 2)
 
         subject.laka
       end
     end
 
-    it "defines an instance-level #status_label method" do
-      expect(MockModel.new(:boom).status_label).to eq 'Boom'
-      expect(MockModel.new(:shaka).status_label).to eq 'Shaka'
-      expect(MockModel.new(:laka).status_label).to eq 'Laka'
+    it "defines an instance-level label method for each status" do
+      expect(MockModel.new(:boom).hype_level_label).to eq 'Boom'
+      expect(MockModel.new(:shaka).hype_level_label).to eq 'Shaka'
+      expect(MockModel.new(:laka).hype_level_label).to eq 'Laka'
     end
     
     it "sets up the correct model validations" do
       MockModel.validation_input.tap do |validation|
-        expect(validation[:field]).to eq :status
+        expect(validation[:field]).to eq :hype_level
         expect(validation[:presence]).to eq true
-        expect(validation[:inclusion][:in].call).to eq [0, 1, 2]
+        expect(validation[:inclusion][:in]).to eq [0, 1, 2]
       end
     end
   end

--- a/spec/simplest_status/status_collection_spec.rb
+++ b/spec/simplest_status/status_collection_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SimplestStatus::StatusCollection do
   let(:shaka) { SimplestStatus::Status.new([:shaka, 1]) }
   let(:laka)  { SimplestStatus::Status.new([:laka, 2]) }
 
-  subject { described_class.new }
+  subject { described_class.new(:status) }
 
   describe "#each" do
     subject { described_class.new.merge!(:boom => 0, :shaka => 1, :laka => 2) }
@@ -41,8 +41,8 @@ RSpec.describe SimplestStatus::StatusCollection do
     end
 
     context "given input that does not match a status's name or value" do
-      it "returns nil" do
-        expect(subject.status_for('boom')).to eq nil
+      it "returns a NullStatus" do
+        expect(subject.status_for('boom')).to be_an_instance_of SimplestStatus::StatusCollection::NullStatus
       end
     end
   end
@@ -78,5 +78,27 @@ RSpec.describe SimplestStatus::StatusCollection do
     subject { described_class.new.merge!(:boom => 0, :shaka => 1, :laka => 2) }
 
     it { expect(subject.for_select).to eq [['Boom', 0], ['Shaka', 1], ['Laka', 2]] }
+  end
+
+  describe "#configure_for" do
+    let(:methods) { double('SimplestStatus::ModelMethods') }
+
+    before do
+      allow(SimplestStatus::ModelMethods).to receive(:new).with(String, subject).and_return(methods)
+    end
+
+    it "configures the given model with the status collection" do
+      expect(methods).to receive(:add)
+
+      subject.configure_for(String)
+    end
+  end
+
+  describe "#status_name" do
+    it { expect(subject.status_name).to eq :status }
+  end
+
+  describe "#model_accessor" do
+    it { expect(subject.model_accessor).to eq 'statuses' }
   end
 end

--- a/spec/simplest_status_spec.rb
+++ b/spec/simplest_status_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SimplestStatus do
 
       statuses :boom, :shaka, :laka
 
-      simple_status :jam_level, %i(heating_up on_fire)
+      simple_status :jam_level, [:heating_up, :on_fire]
     end
 
     describe ".statuses" do

--- a/spec/simplest_status_spec.rb
+++ b/spec/simplest_status_spec.rb
@@ -8,14 +8,22 @@ RSpec.describe SimplestStatus do
   context "when extended by a model" do
     class EmptyModel
       extend SimplestStatus
+
+      def self.validates(*args)
+        #no op
+      end
+
+      statuses :boom, :shaka, :laka
+
+      custom_status :jam_level, %i(heating_up on_fire)
     end
 
-    before do
-      allow(EmptyModel).to receive(:include).with(SimplestStatus::ModelMethods)
+    describe ".statuses" do
+      it { expect(EmptyModel.statuses).to eq(:boom => 0, :shaka => 1, :laka => 2) }
     end
 
-    it "adds the .statuses method" do
-      expect(EmptyModel.statuses(:boom, :shaka, :laka)).to eq(:boom => 0, :shaka => 1, :laka => 2)
+    describe ".custom_status" do
+      it { expect(EmptyModel.jam_levels).to eq(:heating_up => 0, :on_fire => 1) }
     end
   end
 end

--- a/spec/simplest_status_spec.rb
+++ b/spec/simplest_status_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe SimplestStatus do
 
       statuses :boom, :shaka, :laka
 
-      custom_status :jam_level, %i(heating_up on_fire)
+      simple_status :jam_level, %i(heating_up on_fire)
     end
 
     describe ".statuses" do
       it { expect(EmptyModel.statuses).to eq(:boom => 0, :shaka => 1, :laka => 2) }
     end
 
-    describe ".custom_status" do
+    describe ".simple_status" do
       it { expect(EmptyModel.jam_levels).to eq(:heating_up => 0, :on_fire => 1) }
     end
   end


### PR DESCRIPTION
## Overview

This PR adds a new `simple_status` method that allows users to use SimplestStatus functionality with any column name:

``` ruby
class Post < ActiveRecord::Base
  extend SimplestStatus

  simple_status :locale, %i(english spanish russian)
end
```

Fixes #2.
